### PR TITLE
Use the same version for both of instances

### DIFF
--- a/01-config/docker-compose.yml
+++ b/01-config/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       - 28082:28082
       - 29092:29092
   redpanda-2:
-    image: docker.redpanda.com/vectorized/redpanda:v22.2.2
+    image: docker.redpanda.com/vectorized/redpanda:v23.1.7
     container_name: redpanda-2
     command:
       - redpanda


### PR DESCRIPTION
Without this change, the cluster cannot be formed.

`Rejecting join request from incompatible node`